### PR TITLE
Removing the print omap_wdt: Unexpected close, not stopping

### DIFF
--- a/drivers/watchdog/omap_wdt.c
+++ b/drivers/watchdog/omap_wdt.c
@@ -174,8 +174,6 @@ static int omap_wdt_release(struct inode *inode, struct file *file)
 	omap_wdt_disable(wdev);
 
 	pm_runtime_put_sync(wdev->dev);
-#else
-	printk(KERN_CRIT "omap_wdt: Unexpected close, not stopping!\n");
 #endif
 	wdev->omap_wdt_users = 0;
 


### PR DESCRIPTION
Removed the print "omap_wdt: Unexpected close, not stopping" , since this print is coming always once we enable the omap watchdog forever
